### PR TITLE
Conditionally link Python libraries if found in USD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,10 +17,12 @@ project (usd_from_gltf)
 
 # We don't use Python in this tool, but when the USD library is built with
 # PXR_PYTHON_SUPPORT_ENABLED it references it anyway.
-find_package(Python COMPONENTS Development)
-if (NOT Python_FOUND)
-  message(FATAL_ERROR "Missing python libs.")
-endif (NOT Python_FOUND)
+if (EXISTS "${USD_DIR}/lib/python/")
+  find_package(Python COMPONENTS Development)
+  if (NOT Python_FOUND)
+    message(FATAL_ERROR "Missing python libs.")
+  endif (NOT Python_FOUND)
+endif (EXISTS "${USD_DIR}/lib/python/")
 
 set(USD_INCLUDE_DIRS
   "${USD_DIR}/include"
@@ -52,7 +54,6 @@ elseif (APPLE)
 set(USD_LIBS
   ${Python_LIBRARIES}
   -lpthread
-  "${USD_DIR}/lib/libboost_python.dylib"
   libgf.dylib
   libplug.dylib
   libsdf.dylib
@@ -64,11 +65,13 @@ set(USD_LIBS
   libusdUtils.dylib
   libvt.dylib
 )
+if (Python_FOUND)
+  list(APPEND USD_LIBS "${USD_DIR}/lib/libboost_python.dylib")
+endif (Python_FOUND)
 else ()
 set(USD_LIBS
   ${Python_LIBRARIES}
   -lpthread
-  "${USD_DIR}/lib/libboost_python.so"
   libgf.so
   libplug.so
   libsdf.so
@@ -80,6 +83,9 @@ set(USD_LIBS
   libusdUtils.so
   libvt.so
 )
+if (Python_FOUND)
+  list(APPEND USD_LIBS "${USD_DIR}/lib/libboost_python.so")
+endif (Python_FOUND)
 endif ()
 
 if (MSVC)


### PR DESCRIPTION
Currently the Python development libraries are always linked into the project even if USD was compiled without Python support. This PR tries to remedy that by checking if the Python libraries are found in USD directory.

This is useful when trying to use `usd_from_gltf` in environments that don't have Python libraries available.

So far I've only tested this change on Amazon Linux, but testing on a Debian distro in addition to Mac and Windows would be ideal.

Additionally, any feedback regarding the detection of Python support in USD would be appreciated. I'm uncertain if CMake has a better way of determining this.