### PR TITLE
Fixed invalid Boost version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ set(USD_INCLUDE_DIRS
   "${USD_DIR}/include/boost-1_61"
 # Visual Studio 2017 requires boost 1.65.1.
   "${USD_DIR}/include/boost-1_65_1"
+  "${USD_DIR}/include/boost-1_70"
   ${Python_INCLUDE_DIRS}
 )
 

--- a/process/mesh.h
+++ b/process/mesh.h
@@ -18,6 +18,7 @@
 #define UFG_PROCESS_MESH_H_
 
 #include <limits>
+#include <map>
 #include "common/common.h"
 #include "common/logging.h"
 #include "gltf/cache.h"


### PR DESCRIPTION
Fixed #54  #57 

- Added reference to Boost 1.70 (used in USD 20.11)
- Fixed compilation error  in `mesh.h`